### PR TITLE
chore: use PAT-style git remote auth in next-upgrade

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Configure authenticated origin
       shell: bash
       run: |
-        git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+        git remote set-url origin "https://${{ github.repository_owner }}:${{ inputs.gh_token }}@github.com/${{ github.repository }}.git"
     - name: Create Pull Request
       id: create_pr
       uses: peter-evans/create-pull-request@v7.0.8


### PR DESCRIPTION
Use repository owner plus gh_token for git remote URL auth before create-pull-request to avoid remote prune authentication failures.