### PR TITLE
chore: use git_token for create-pull-request auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       id: create_pr
       uses: peter-evans/create-pull-request@v7.0.8
       with:
-        token: ${{ inputs.gh_token }}
+        token: ${{ inputs.git_token }}
         branch-token: ${{ inputs.git_token }}
         commit-message: |
           chore(deps): upgrade dependencies


### PR DESCRIPTION
Use git_token for both API and git branch operations in create-pull-request to avoid bad PAT credentials.