### PR TITLE
chore: only upgrade production deps in next-upgrade

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Update Dependencies
       shell: bash
       run: |
-        pnpm up --latest
+        pnpm up --latest --prod
         pnpm add -D tailwindcss@^3.4.18
     - name: Generate Delta
       shell: bash


### PR DESCRIPTION
Run pnpm up --latest --prod to avoid breaking CI via major lint stack upgrades.