### PR TITLE
chore: remove forced tailwind v3 downgrade from next-upgrade

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ runs:
       shell: bash
       run: |
         pnpm up --latest --prod
-        pnpm add -D tailwindcss@^3.4.18
     - name: Generate Delta
       shell: bash
       run: |


### PR DESCRIPTION
Keep dependency upgrades compatible with Tailwind v4 projects by removing the hardcoded tailwindcss@3 install step.