### PR TITLE
chore: centralize github token normalization

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,32 +32,11 @@ runs:
         git diff
     - name: Normalize GitHub token
       id: token
-      shell: bash
-      run: |
-        sanitize() {
-          local t="$1"
-          t="${t#https://x-access-token:}"
-          t="${t#x-access-token:}"
-          t="${t%@github.com*}"
-          echo "$t"
-        }
-
-        preferred="$(sanitize "${{ inputs.git_token }}")"
-        fallback="$(sanitize "${{ inputs.gh_token }}")"
-        default_token="$(sanitize "${{ github.token }}")"
-        auth_ok() {
-          local t="$1"
-          [[ -n "$t" ]] || return 1
-          curl -fsS -H "Authorization: Bearer ${t}" https://api.github.com/user >/dev/null
-        }
-
-        if auth_ok "${preferred}"; then
-          echo "value=${preferred}" >> "$GITHUB_OUTPUT"
-        elif auth_ok "${fallback}"; then
-          echo "value=${fallback}" >> "$GITHUB_OUTPUT"
-        else
-          echo "value=${default_token}" >> "$GITHUB_OUTPUT"
-        fi
+      uses: p6m7g8-actions/gh-token-normalize@main
+      with:
+        preferred-token: ${{ inputs.git_token }}
+        fallback-token: ${{ inputs.gh_token }}
+        default-token: ${{ github.token }}
     - name: Configure authenticated git remote
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- remove inline token normalization/auth shell logic
- use shared p6m7g8-actions/gh-token-normalize@main action

## Testing
- yamllint action.yml (existing baseline warnings only)