### PR TITLE
fix: use P6_A_GH_TOKEN first for upgrade PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,10 @@ description: "P6 GHA: Upgrade Dependencies for NextJS Static Site"
 author: "Philip M. Gollucci"
 inputs:
   gh_token:
-    description: "Fallback GitHub token (e.g., P6_A_GH_TOKEN)"
-    required: false
-    default: ""
+    description: "GitHub token used for PR creation (P6_A_GH_TOKEN)"
+    required: true
   git_token:
-    description: "Secondary fallback token for branch operations"
+    description: "Optional extra fallback token for branch operations"
     required: false
     default: ""
 runs:
@@ -36,8 +35,8 @@ runs:
       id: token
       uses: p6m7g8-actions/gh-token-normalize@main
       with:
-        preferred-token: ${{ github.token }}
-        fallback-token: ${{ inputs.gh_token }}
+        preferred-token: ${{ inputs.gh_token }}
+        fallback-token: ${{ inputs.git_token }}
         default-token: ${{ github.token }}
     - name: Configure authenticated git remote
       shell: bash


### PR DESCRIPTION
## Summary
- make `gh_token` required again
- prefer `gh_token` for PR creation token selection
- use `git_token` as optional second fallback
- keep `github.token` as final fallback
- preserve reviewer/labels for auto-approve and merge-queue

## Why
PRs created with `github.token` can suppress downstream PR workflows in some repos.

## Testing
- yamllint action.yml (existing warning baseline only)