### PR TITLE
fix: fall back to github.token for relabel step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       if: steps.create_pr.outputs.pull-request-number != ''
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.gh_token }}
+        GH_TOKEN: ${{ inputs.gh_token || github.token }}
       run: |
         pr="${{ steps.create_pr.outputs.pull-request-number }}"
         repo="${{ github.repository }}"


### PR DESCRIPTION
Prevent upgrade-main workflow failure when `gh_token` is omitted by falling back to `github.token` for the re-label step.