### PR TITLE
fix: sign upgrade commits and fire the checks they cannot trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ```yaml
       - name: Upgrade Deps
-        uses: p6m7g8-actions/next-upgrade@main
+        uses: p6m7g8-actions/p6-next-upgrade@main
         with:
           gh_token: ${{ secrets.P6_PGOLLUCCI_GH_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -60,8 +60,18 @@ runs:
           p6m7g8-automation
         body: |
           Upgrades project dependencies.
-        author: github-actions <github-actions@github.com>
-        committer: github-actions <github-actions@github.com>
+        # Every target enforces `required_signatures`, and a commit made by
+        # `git commit` on a runner has no key. Unsigned upgrade PRs were rejected
+        # by the merge queue with "Commits must have verified signatures" and sat
+        # open for months; the batch from 2026-03-03 never had a chance.
+        #
+        # `sign-commits` makes the action create the commit through the GitHub
+        # API, which signs it. It only works with GITHUB_TOKEN or a GitHub App
+        # token -- with a PAT the PR is still created but the commits are
+        # silently NOT signed. That is why the token above resolves to
+        # `github.token`, and why `author`/`committer` are gone: upstream ignores
+        # both when signing.
+        sign-commits: true
         signoff: true
     - name: Re-label PR with automation token
       if: steps.create_pr.outputs.pull-request-number != ''
@@ -73,3 +83,29 @@ runs:
         repo="${{ github.repository }}"
         gh api -X DELETE "repos/${repo}/issues/${pr}/labels/auto-approve" || true
         gh api "repos/${repo}/issues/${pr}/labels" -f labels[]='auto-approve'
+
+    # Signing forces GITHUB_TOKEN, and GitHub deliberately does not dispatch
+    # workflows for events raised by it. So a signed upgrade PR gets NO
+    # `build`, `Lint PR title`, or `claude-review` -- all three are required, so
+    # it is blocked on missing checks instead of on signatures. Verified on
+    # p6m7g8/p6-domain-records: bot PR #185 had only `Summary`, while #184 from
+    # a user token one day earlier had the full suite.
+    #
+    # Closing and reopening with the automation PAT raises a `reopened` event
+    # from a non-GITHUB_TOKEN identity, which does dispatch. Every build template
+    # accepts `reopened`, either explicitly or via the `pull_request` defaults.
+    #
+    # The proper fix is a GitHub App token, which both signs and dispatches.
+    # This is the workaround until one exists.
+    - name: Fire required checks the signed PR cannot trigger itself
+      if: steps.create_pr.outputs.pull-request-number != '' && inputs.gh_token != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        set -euo pipefail
+        pr="${{ steps.create_pr.outputs.pull-request-number }}"
+        repo="${{ github.repository }}"
+        echo "::notice::$repo#$pr: reopening with the automation token so required checks dispatch"
+        gh pr close "$pr" --repo "$repo"
+        gh pr reopen "$pr" --repo "$repo"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         fetch-depth: 0
     - name: Force main branch
@@ -22,7 +22,7 @@ runs:
         git fetch origin main
         git checkout -B main origin/main
     - name: Node
-      uses: p6m7g8-actions/node-setup@main
+      uses: p6m7g8-actions/p6-node-setup@main
     - name: Update Dependencies
       shell: bash
       run: |
@@ -33,7 +33,7 @@ runs:
         git diff
     - name: Normalize GitHub token
       id: token
-      uses: p6m7g8-actions/gh-token-normalize@main
+      uses: p6m7g8-actions/gh-token-resolve@main
       with:
         preferred-token: ${{ github.token }}
         fallback-token: ${{ inputs.gh_token }}


### PR DESCRIPTION
**What:** Sets `sign-commits: true` on `peter-evans/create-pull-request`, drops the now-ignored `author`/`committer` inputs, and adds a step that fires the required checks the signed PR cannot trigger itself.

**Why:** Every dependency-upgrade PR in this fleet was permanently unmergeable, for two stacked reasons. 20 PRs were sitting open because of it, the oldest from 2024-10-24; those have now been closed with their branches preserved.

**Blocker 1, unsigned commits.** Every target enforces `required_signatures`. `create-pull-request` commits via git by default, so the merge queue rejected them with `Commits must have verified signatures`. `sign-commits: true` makes the action create the commit through the GitHub API, which signs it.

**Blocker 2, which the first fix causes.** `sign-commits` only works with `GITHUB_TOKEN` or a GitHub App token. With a PAT the PR is still created but commits are *silently* not signed. So signing pins us to `GITHUB_TOKEN` — and GitHub deliberately does not dispatch workflows for events raised by it. A signed upgrade PR therefore gets **no** `build`, `Lint PR title`, or `claude-review`, all three of which are required. It trades "blocked on signatures" for "blocked on missing checks".

This is measured, not theorised. On `p6m7g8/p6-domain-records`, bot PR #185 had only `Summary` and a legacy `Mergify Merge Queue` check, while PR #184 from a user token one day earlier had the full suite: `build`, `Lint PR title`, `Auto-Approve PR`, and the rest.

**The workaround:** after creating the PR, close and reopen it with the automation PAT. That raises a `reopened` event from a non-`GITHUB_TOKEN` identity, which does dispatch. Every build template accepts `reopened`, either explicitly (`p6m7g8-actions`) or via the `pull_request` defaults (all other orgs). This also finally gives `inputs.gh_token` a purpose: `preferred-token: github.token` made the PAT fallback dead code, so the input was declared `required: true` and never used for anything but re-labelling.

**The proper fix is a GitHub App token,** which both signs commits and dispatches workflows, removing the need for the reopen entirely. That needs an App created and installed across six orgs, so it is out of scope here and noted in the code.

**Test plan:** All five actions parse as valid YAML and were verified structurally: `sign-commits: true` present, `author`/`committer` absent from the `with:` block, and exactly one nudge step each. The behaviour is verified end to end on `p6-uv-upgrade` against a real repo, since that has the fastest upgrade cycle; results posted in a comment below before this merges.

`actionlint` reports "jobs section is missing" on these files, which is expected — they are composite actions, not workflows.

**Dependencies:** none. All five are independent.
