### PR TITLE
fix(upgrade): hold typescript across pnpm up --latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: "Optional extra fallback token for branch operations"
     required: false
     default: ""
+  hold_dependencies:
+    description: >-
+      Space-separated packages whose package.json range must survive the
+      upgrade. See the Update Dependencies step for why typescript is held.
+    required: false
+    default: "typescript"
 runs:
   using: "composite"
   steps:
@@ -25,8 +31,48 @@ runs:
       uses: p6m7g8-actions/p6-node-setup@main
     - name: Update Dependencies
       shell: bash
+      env:
+        HOLD: ${{ inputs.hold_dependencies }}
       run: |
+        set -euo pipefail
+
+        # `pnpm up --latest` ignores package.json ranges by design, and pnpm has
+        # no dependency-name exclusion: the `!` negation in `pnpm up --help` is
+        # `--filter` only, which selects workspace packages, not dependencies.
+        # So snapshot the declared ranges, upgrade, then put the held ones back
+        # and let pnpm re-resolve the lockfile.
+        #
+        # `typescript` is held by default because the 2026-08-02 run bumped it
+        # 5.9.3 to 7.0.2 and broke `build` fleet-wide two ways:
+        # `@typescript-eslint` 8.65.0 exits 2 with "typescript-eslint does not
+        # support TS 7.0", and ts-node throws on `fileExists`. Verified on
+        # p6-domains that holding typescript alone, with every other upgrade
+        # applied, makes `pnpm run build` pass. Drop this default once the
+        # eslint toolchain supports TS 7.
+        before="$(mktemp)"
+        cp package.json "$before"
+
         pnpm up --latest --prod
+
+        if [ -n "${HOLD//[[:space:]]/}" ]; then
+          read -ra hold <<< "$HOLD"
+          for pkg in "${hold[@]}"; do
+            range="$(jq -r --arg p "$pkg" \
+              '.dependencies[$p] // .devDependencies[$p] // empty' "$before")"
+            if [ -z "$range" ]; then
+              echo "::notice::${pkg} not declared; nothing to hold"
+              continue
+            fi
+            patched="$(mktemp)"
+            jq --arg p "$pkg" --arg r "$range" \
+              'if .dependencies[$p] then .dependencies[$p] = $r
+               else .devDependencies[$p] = $r end' \
+              package.json > "$patched"
+            mv "$patched" package.json
+            echo "::notice::held ${pkg} at ${range}"
+          done
+          pnpm install --no-frozen-lockfile
+        fi
     - name: Generate Delta
       shell: bash
       run: |


### PR DESCRIPTION
## What

Hold `typescript` at its declared `package.json` range across `pnpm up --latest --prod`, via a new `hold_dependencies` input (default `typescript`).

## Why

`pnpm up --latest` ignores `package.json` ranges by design, and pnpm has **no dependency-name exclusion** — the `!` negation in `pnpm up --help` applies to `--filter`, which selects workspace packages, not dependencies. So on 2026-08-02 this action bumped `typescript` from `~5.9.3` to `~7.0.2` and broke `build` across the fleet two ways:

- `@typescript-eslint` 8.65.0 exits 2 with `Error: typescript-eslint does not support TS 7.0.`
- ts-node throws `TypeError: Cannot read properties of undefined (reading 'fileExists')`

Both consumers of this action currently have BLOCKED upgrade PRs for exactly this reason: `p6m7g8/p6m7g8.com#250` and `p6m7g8/p6-template-next-tailwind-react-eslint-pnpm-ts-flatfile#137`.

Since exclusion is not available, the step snapshots the declared ranges, runs the upgrade, restores the held ranges, and lets pnpm re-resolve the lockfile. Only `typescript` is held; nothing else is capped, so every other upgrade still lands. The default should be dropped once the eslint toolchain supports TS 7.

## Test plan

- **Root-cause verification (p6-domains, local):** holding `typescript` at `~5.9.3` while keeping **every** other upgrade makes `pnpm run build` exit 0. This is what establishes that `typescript` alone is the breakage and that no other cap is needed.
- **Hold logic, unit-tested locally under bash** against a synthetic `package.json` — all three cases pass:
  - prod dependency held at its old range while a sibling (`next`) keeps its upgrade
  - `devDependencies` fallback works, and an undeclared package emits the `nothing to hold` notice instead of failing
  - whitespace-only / empty `hold_dependencies` is a clean no-op that skips the extra `pnpm install`
- `actionlint` — clean, exit 0.
- `shellcheck -s bash` on the extracted `Update Dependencies` script — clean, exit 0.
- `yamllint` with the relaxed config that `p6-yaml-lint` generates (`line-length: max 120, level warning`) — 0 errors repo-wide; the only findings on `action.yml` are two pre-existing warnings also present on `main`.
- `git status` confirmed clean: scratch files use `mktemp`, not the working tree, so `create-pull-request` cannot commit them. Only `action.yml` changed.
- **Upgrade scope is unchanged:** the `--prod` flag is kept exactly as-is. The restore logic reads `.dependencies` first and falls back to `.devDependencies`, so it is correct under either scope.
- `act` was **not** run: the Docker daemon is not running on this machine (`Cannot connect to the Docker daemon`). Relying on remote GHA per policy rather than stalling.

## Dependencies

None.
