### PR TITLE
fix(upgrade): read every held dependency and cover optionalDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [p6m7g8-actions/next-upgrade](#p6m7g8-actionsnext-upgrade)
   - [Usage](#usage)
+  - [Inputs](#inputs)
 
 ## Usage
 
@@ -11,3 +12,36 @@
         with:
           gh_token: ${{ secrets.P6_PGOLLUCCI_GH_TOKEN }}
 ```
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `gh_token` | yes | n/a | Automation token (`P6_A_GH_TOKEN`). Re-labels the PR and reopens it so checks dispatch. |
+| `git_token` | no | `""` | Optional extra fallback token for branch operations. |
+| `hold_dependencies` | no | `typescript` | Packages whose `package.json` range must survive `pnpm up --latest`. |
+
+`hold_dependencies` accepts spaces, newlines, or both, so either form works:
+
+```yaml
+        with:
+          hold_dependencies: "typescript eslint"
+```
+
+```yaml
+        with:
+          hold_dependencies: |
+            typescript
+            eslint
+```
+
+The declared range is snapshotted before the upgrade and written back after,
+then the lockfile is re-resolved. `dependencies`, `devDependencies` and
+`optionalDependencies` are all searched, and a held package is written back to
+the section it was declared in. A package this repo does not declare is
+reported as a notice and skipped. Passing an empty value holds nothing, which
+is not the same as passing nothing: the `typescript` default applies only when
+the input is absent.
+
+`typescript` is held by default because TS 7 breaks `build` fleet-wide; see the
+Update Dependencies step in `action.yml` for the detail and for when to drop it.

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,9 @@ inputs:
     default: ""
   hold_dependencies:
     description: >-
-      Space-separated packages whose package.json range must survive the
-      upgrade. See the Update Dependencies step for why typescript is held.
+      Packages whose package.json range must survive the upgrade, separated by
+      spaces, newlines, or both. See the Update Dependencies step for why
+      typescript is held.
     required: false
     default: "typescript"
 runs:
@@ -55,23 +56,43 @@ runs:
         pnpm up --latest --prod
 
         if [ -n "${HOLD//[[:space:]]/}" ]; then
-          read -ra hold <<< "$HOLD"
+          # `read` consumes ONE line, so a `hold_dependencies: |` block -- the
+          # dominant Actions idiom, one package per line -- would silently hold
+          # only the first entry and upgrade the rest. Flatten newlines to
+          # spaces first so both spellings behave the same. The emptiness guard
+          # above already covers newline-only input.
+          read -ra hold <<< "${HOLD//$'\n'/ }"
+          held=0
           for pkg in "${hold[@]}"; do
+            # `--prod` above scopes the upgrade to `dependencies` AND
+            # `optionalDependencies`, so omitting the latter here reported
+            # "nothing to hold" while the package was in fact being upgraded.
             range="$(jq -r --arg p "$pkg" \
-              '.dependencies[$p] // .devDependencies[$p] // empty' "$before")"
+              '.dependencies[$p] // .devDependencies[$p]
+               // .optionalDependencies[$p] // empty' "$before")"
             if [ -z "$range" ]; then
               echo "::notice::${pkg} not declared; nothing to hold"
               continue
             fi
             patched="$(mktemp)"
+            # Each branch names the section the range was found in. A bare
+            # `else .devDependencies[$p] = $r` would CREATE a devDependencies
+            # entry for an optionalDependencies-only package, moving it between
+            # sections behind your back.
             jq --arg p "$pkg" --arg r "$range" \
               'if .dependencies[$p] then .dependencies[$p] = $r
-               else .devDependencies[$p] = $r end' \
+               elif .devDependencies[$p] then .devDependencies[$p] = $r
+               else .optionalDependencies[$p] = $r end' \
               package.json > "$patched"
             mv "$patched" package.json
+            held=$((held + 1))
             echo "::notice::held ${pkg} at ${range}"
           done
-          pnpm install --no-frozen-lockfile
+          # Only re-resolve when a range actually changed. If every requested
+          # package was undeclared, the lockfile pnpm just wrote is correct.
+          if [ "$held" -gt 0 ]; then
+            pnpm install --no-frozen-lockfile
+          fi
         fi
     - name: Generate Delta
       shell: bash


### PR DESCRIPTION
## What

Fix two correctness defects in the `hold_dependencies` logic: only the first line
of a multi-line value was read, and `optionalDependencies` was neither searched
nor written back.

## Why

Both defects were found by this repo's own `claude-review` on PR #44 and were
knowingly deferred, because #44 was unblocking a live fleet-wide `build` break
(TS 5.9.3 to 7.0.2 broke `@typescript-eslint` and ts-node everywhere). Shipping
the hold at all mattered more in that moment than shipping it complete. This PR
closes that debt before any caller starts passing `hold_dependencies`
explicitly, which is the point at which both bugs become reachable.

Neither bites on the default value `typescript`, so nothing is broken today.
Both are silent-wrong-answer bugs: they report success while upgrading a package
the caller asked to hold, the same fail-open class the step exists to prevent.

**Defect 1, `read -ra` consumed only the first line.** `read` reads one line, so
a `hold_dependencies: |` block, the dominant Actions idiom, held only the first
entry and silently upgraded the rest. Newlines are now flattened to spaces
before word splitting, so space-separated, newline-separated and mixed input all
behave identically. The existing `${HOLD//[[:space:]]/}` emptiness guard is
untouched and already covers newline-only input.

**Defect 2, `optionalDependencies` was invisible.** This action runs
`pnpm up --latest --prod`, and `--prod` scopes the upgrade to `dependencies`
**and** `optionalDependencies`. The lookup searched only `dependencies` and
`devDependencies`, so an optional-only package reported `nothing to hold` while
being upgraded anyway. That makes this defect more relevant here than in the
sibling upgrade actions.

The two halves of defect 2 are in one commit deliberately. The bad
`else .devDependencies[$p] = $r` writeback fallthrough is **latent** on `main`:
the old lookup returns `empty` for an optional-only package, the loop hits
`continue`, and the writeback never runs. Fixing the lookup alone makes that
fallthrough reachable and strictly worse than the original bug. Verified by
building that hybrid deliberately and running it:

```json
{
  "devDependencies":      { "fsevents": "2.3.3" },   // bogus section invented
  "optionalDependencies": { "fsevents": "^99.0.0" }  // real range still upgraded
}
```

Wrong section created, duplicate declaration, and the hold defeated anyway.

Also included, matching what `p6-cdk-upgrade#32` and `p6-cdktf-upgrade#28` did so
the three actions do not drift apart:

- The `pnpm install --no-frozen-lockfile` re-resolve is gated behind a `held`
  counter, so it no longer runs when every requested package was undeclared and
  no range was rewritten. Efficiency, not correctness.
- The `hold_dependencies` input description no longer claims "Space-separated",
  which became wrong once multi-line parsing works.

`pnpm up --latest --prod` is unchanged. Upgrade scope is exactly as it was.

## Test plan

The hold logic was extracted programmatically from the shipped `action.yml`
`Update Dependencies` block rather than retyped, and the extractor asserts all
four shipped fragments are present so it fails loudly if it ever drifts. Only
the two `pnpm` calls are stubbed: `pnpm up` rewrites every declared range to
`^99.0.0` so a restored range is observable, and it bumps all three sections
deliberately, broader than the real `--prod` scope, so the writeback target
section is provable for every fixture.

30 assertions across 7 fixtures, all passing against the shipped code:

| Fixture | Asserts |
| --- | --- |
| 1. multi-line `HOLD`, three packages | all three held; unlisted package still upgraded; `held=3`; re-resolve ran |
| 2. `optionalDependencies`-only package | held in place; **no `devDependencies` key created**; no bogus `nothing to hold` notice |
| 3. `devDependencies`-only package | held in `devDependencies`; not leaked into either other section |
| 4. undeclared package between two declared | exit 0 under `set -euo pipefail`; notice emitted; the entry *after* it still held, so the loop continued; no stray key |
| 5a. empty `HOLD` | no-op; hold block never entered; no re-resolve |
| 5b. whitespace-only `HOLD` (space, tab, newline) | no-op; emptiness guard still fires |
| 6. mixed, one line carrying two space-separated packages | all four held, across all three sections |

Fixture 2 asserts on key **absence** via `has()`, not on a value. Note for
anyone extending these: jq `|=` is `setpath` and invents absent keys as `null`,
which makes a key-absence assertion silently untrustworthy. An earlier version
of the harness used `|=` in the stub and produced a false failure on exactly
this fixture; it uses `reduce` with `has()` now.

Both fixes were confirmed load-bearing rather than vacuous by re-running the
same fixtures against deliberately broken variants built from the same shipped
text:

- Against `main`'s pre-fix logic: fixtures 1, 2, 4 and 6 fail, each on its
  expected bug signature.
- Against the hybrid (lookup fixed, writeback reverted): fixture 2 fails on
  **both** assertions, reproducing the invented-section corruption above. This
  is what proves the key-absence assertion can actually fail.

Linters, all clean:

- `actionlint -shellcheck=shellcheck .github/workflows/*.yml`, rc=0. `actionlint`
  cannot parse a composite `action.yml` and CI never points it there, so that
  known false positive was not chased.
- `shellcheck -s bash` on every `run` block extracted from `action.yml`, with the
  same exclusions `p6-shell-lint` uses in CI. Clean, and the changed block is
  also clean with no exclusions at all.
- `yamllint` under the relaxed config `p6-yaml-lint` generates, rc=0. Warnings
  only; the sole `line-length` warning is a pre-existing 131-char line that
  predates this change, and the longest line added here is 97 chars.
- `markdownlint` under the 120-col default `p6-markdown-lint` generates, rc=0.
- `cspell` was checked against the config generated from `.vscode/settings.json`.
  The one new word is `elif`, already shipping in six sibling `action.yml` files
  in this org, including the merged `p6-cdk-upgrade#32`.

`act` was not run: the Docker daemon is down on this host
(`Cannot connect to the Docker daemon`). Relying on remote GHA per policy.

## Dependencies

None. `p6-cdk-upgrade#32` (merged as `44d3c5d`, `v0.2.6`) and
`p6-cdktf-upgrade#28` carry the equivalent fix in the sibling actions, but
nothing here depends on either.
